### PR TITLE
Convert byte32 symbols into string

### DIFF
--- a/src/common/TokenParser.ts
+++ b/src/common/TokenParser.ts
@@ -84,7 +84,8 @@ export class TokenParser {
                 const p3 = contractInstance.methods.decimals().call();
                 const p4 = contractInstance.methods.symbol().call();
 
-                promises.push(Promise.all([p1, p2, p3, p4]).then(([name, totalSupply, decimals, symbol]: any[]) => {
+                promises.push(Promise.all([p1, p2, p3, p4]).then(([name, totalSupply, decimals, receivedSymbol]: any[]) => {
+                    let symbol = this.convertSymbol(receivedSymbol)
                     return [name, totalSupply, decimals, symbol];
                 }).catch((err: Error) => {
                     /* don't do anything here, but catch error */
@@ -112,6 +113,13 @@ export class TokenParser {
                 });
             });
         });
+    }
+
+    private convertSymbol(symbol: string): any {
+        if (symbol.startsWith('0x')) {
+            return Config.web3.utils.hexToAscii(symbol);
+        }
+        return symbol
     }
 
     private updateERC20Token(contract: String, obj: any): Promise<void> {

--- a/src/common/TokenParser.ts
+++ b/src/common/TokenParser.ts
@@ -85,7 +85,7 @@ export class TokenParser {
                 const p4 = contractInstance.methods.symbol().call();
 
                 promises.push(Promise.all([p1, p2, p3, p4]).then(([name, totalSupply, decimals, receivedSymbol]: any[]) => {
-                    let symbol = this.convertSymbol(receivedSymbol)
+                    const symbol = this.convertSymbol(receivedSymbol)
                     return [name, totalSupply, decimals, symbol];
                 }).catch((err: Error) => {
                     /* don't do anything here, but catch error */
@@ -115,7 +115,7 @@ export class TokenParser {
         });
     }
 
-    private convertSymbol(symbol: string): any {
+    private convertSymbol(symbol: string): string | byte32 {
         if (symbol.startsWith('0x')) {
             return Config.web3.utils.hexToAscii(symbol);
         }

--- a/src/common/TokenParser.ts
+++ b/src/common/TokenParser.ts
@@ -115,11 +115,11 @@ export class TokenParser {
         });
     }
 
-    private convertSymbol(symbol: string): string | byte32 {
+    private convertSymbol(symbol: string): string {
         if (symbol.startsWith('0x')) {
             return Config.web3.utils.hexToAscii(symbol);
         }
-        return symbol
+        return symbol;
     }
 
     private updateERC20Token(contract: String, obj: any): Promise<void> {


### PR DESCRIPTION
Contracts like https://etherscan.io/token/EOS#readContract would have symbol as `bytes32`, in that case, we need to convert it into `string`

I tested on old web3 version:
```
web3.toAscii("0x454f530000000000000000000000000000000000000000000000000000000000") =>
"EOS"
```

should be the same call on new web3 version: `web3.utils.hexToAscii()`

@kolya182 can you verify if this works correctly? I don't have env setup just yet