### PR TITLE
Upgrade typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9219,7 +9219,7 @@
         "chalk": "2.3.0",
         "cross-spawn": "5.1.0",
         "ps-tree": "1.1.0",
-        "typescript": "2.6.2"
+        "typescript": "2.7.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9399,9 +9399,9 @@
       }
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ts-node": "^4.1.0",
     "tsc-watch": "^1.0.10",
     "tslint": "^5.0.0",
-    "typescript": "^2.6.2",
+    "typescript": "^2.7.2",
     "web3": "^1.0.0-beta.24",
     "winston": "^2.4.0",
     "xss-filters": "^1.2.7"


### PR DESCRIPTION
TypeScript’s --watch mode now clears the screen after a re-compilation is requested