### PR TITLE
Android register unregister

### DIFF
--- a/src/controllers/DeviceRegistrationController.ts
+++ b/src/controllers/DeviceRegistrationController.ts
@@ -75,7 +75,10 @@ export class DeviceRegistration {
     }
 
     private findOneAndUnregister(res: Response, id) {
-        Device.findOneAndRemove(id).then(removedDevice => {
+        const removeOptions: any = {
+            projection: {_id: 0}
+        }
+        Device.findOneAndRemove(id, removeOptions).then(removedDevice => {
             removedDevice ? this.sendOnUnregisterSuccess(res, removedDevice) : this.sendOnUnregisterFail(404, res, "Can not find device", removedDevice)
         })
     }

--- a/src/controllers/DeviceRegistrationController.ts
+++ b/src/controllers/DeviceRegistrationController.ts
@@ -12,8 +12,8 @@ export class DeviceRegistration {
             isAirdrop: inputPreferences.isAirdrop || false
         }
         const type: string = req.body.type || ""
-        const deviceID: string = req.body.deviceID
-        const token: string = req.body.token
+        const deviceID: string = req.body.deviceID || ""
+        const token: string = req.body.token || ""
         const updatesParams = {
             deviceID,
             wallets,
@@ -41,7 +41,8 @@ export class DeviceRegistration {
         const updateOptions = {
             upsert: true,
             new: true,
-            setDefaultsOnInsert: true
+            setDefaultsOnInsert: true,
+            fields: {_id: 1}
         }
 
         Device.findOneAndUpdate(id, updateParams, updateOptions).then(response => {

--- a/src/controllers/DeviceRegistrationController.ts
+++ b/src/controllers/DeviceRegistrationController.ts
@@ -1,0 +1,104 @@
+import { Request, Response } from "express";
+import { sendJSONresponse } from "../common/Utils";
+import { Device } from "../models/DeviceModel";
+import * as winston from "winston";
+import { ISavedDevice } from "./Interfaces/IPusherController"
+
+export class DeviceRegistration {
+    register = (req: Request, res: Response) => {
+        const wallets = [...(new Set(req.body.wallets.map((wallet: string) => wallet.toLowerCase())))];
+        const inputPreferences = req.body.preferences || {};
+        const preferences = {
+            isAirdrop: inputPreferences.isAirdrop || false
+        }
+        const type: string = req.body.type || ""
+        const deviceID: string = req.body.deviceID
+        const token: string = req.body.token
+        const updateOptions = {
+            upsert: true,
+            new: true,
+            setDefaultsOnInsert: true
+        }
+        const updatesParams = {
+            deviceID,
+            wallets,
+            token,
+            preferences,
+            type
+        }
+
+        try {
+            if (deviceID && token) {
+                Device.findOneAndUpdate({deviceID}, updatesParams, updateOptions).then(registeredDevice => {
+                    this.sendOnRegisterSuccess(res, registeredDevice)
+                })
+            }
+            else if (token && !deviceID && type === "android") {
+                Device.findOneAndUpdate({token}, updatesParams, updateOptions).then(registeredDevice => {
+                    this.sendOnRegisterSuccess(res, registeredDevice)
+                })
+            } else {
+                throw new TypeError()
+            }
+        } catch (error) {
+            winston.error("Failed to save device ", error);
+            this.sendOnRegisterFail(500, res, "Failed to save device, check if token, deviceID, or type specified correctly", error)
+        }
+    }
+
+    unregister = (req: Request, res: Response) => {
+        const deviceID: string = req.body.deviceID
+        const token: string = req.body.token
+        const type: string = req.body.type
+
+        try {
+            if (deviceID) {
+                Device.findOneAndRemove({deviceID}).then((removedDevice) => {
+                    removedDevice ? this.sendOnUnregisterSuccess(res, removedDevice) : this.sendOnUnregisterFail(404, res, "Can not find device", removedDevice)
+                })
+            }
+            else if (token && !deviceID && type === "android") {
+                Device.findOneAndRemove({token}).then((removedDevice) => {
+                    removedDevice ? this.sendOnUnregisterSuccess(res, removedDevice) : this.sendOnUnregisterFail(404, res, "Can not find device", removedDevice)
+                })
+            } else {
+                throw new TypeError()
+            }
+        } catch (error) {
+            winston.info(`Error unregistering `, error)
+            this.sendOnUnregisterFail(500, res, "Failed to remove", error)
+        }
+    }
+
+   private sendOnRegisterSuccess(res: Response, registeredDevice) {
+        sendJSONresponse(res, 200, {
+            status: 200,
+            message: "Successfully saved",
+            response: registeredDevice,
+        });
+    }
+
+    private sendOnRegisterFail(code: number, res: Response, message: string, error) {
+        sendJSONresponse(res, code, {
+            status: code,
+            message,
+            error,
+        })
+    }
+
+    private sendOnUnregisterSuccess (res: Response, removedDevice) {
+        sendJSONresponse(res, 200, {
+            status: 200,
+            message: "Successfully unregistered",
+            response: removedDevice,
+        })
+    }
+
+    private sendOnUnregisterFail(code: number = 500, res: Response, message: string, error) {
+        sendJSONresponse(res, code, {
+            status: code,
+            message,
+            error,
+        })
+    }
+}

--- a/src/controllers/DeviceRegistrationController.ts
+++ b/src/controllers/DeviceRegistrationController.ts
@@ -42,7 +42,7 @@ export class DeviceRegistration {
             upsert: true,
             new: true,
             setDefaultsOnInsert: true,
-            fields: {_id: 1}
+            fields: {_id: 0}
         }
 
         Device.findOneAndUpdate(id, updateParams, updateOptions).then(response => {

--- a/src/controllers/PusherController.ts
+++ b/src/controllers/PusherController.ts
@@ -6,41 +6,49 @@ import { Error } from "mongoose";
 import { ISavedDevice } from "./Interfaces/IPusherController"
 
 export class Pusher {
-    register(req: Request, res: Response) {
-        const wallets: string[] = req.body.wallets.map((wallet: string) => wallet.toLowerCase());
-        const unuqieWallets = [...(new Set(wallets))];
+    register = (req: Request, res: Response) => {
+        const wallets = [...(new Set(req.body.wallets.map((wallet: string) => wallet.toLowerCase())))];
         const inputPreferences = req.body.preferences || {};
         const preferences = {
             isAirdrop: inputPreferences.isAirdrop || false
         }
         const type: string = req.body.type || ""
-
-        Device.findOneAndUpdate({
-            deviceID: req.body.deviceID
-        }, {
-            wallets: unuqieWallets,
-            token: req.body.token,
-            preferences,
-            type
-        }, {
+        const deviceID: string = req.body.deviceID
+        const token: string = req.body.token
+        const updateOptions = {
             upsert: true,
             new: true,
             setDefaultsOnInsert: true
         }
-        ).then((savedDevice: ISavedDevice) => {
-            sendJSONresponse(res, 200, {
-                status: 200,
-                message: "Successfully saved",
-                response: savedDevice,
-            });
-        }).catch((error: Error) => {
-            winston.error("Failed to save device ", error);
+        const updatesParams = {
+            deviceID,
+            wallets,
+            token,
+            preferences,
+            type
+        }
+
+        try {
+            if (deviceID && token) {
+                Device.findOneAndUpdate({deviceID}, updatesParams, updateOptions).then(registeredDevice => {
+                    this.sendOnRegister(res, registeredDevice)
+                })
+            }
+            else if (token && !deviceID && type === "android") {
+                Device.findOneAndUpdate({token}, updatesParams, updateOptions).then(registeredDevice => {
+                    this.sendOnRegister(res, registeredDevice)
+                })
+            } else {
+                throw new TypeError()
+            }
+        } catch (error) {
+            winston.error(`Failed to save device `, error);
             sendJSONresponse(res, 500, {
                 status: 500,
-                message: "Failed to save device",
+                message: "Failed to save device, check if token, deviceID, or type specified correctly",
                 error,
               });
-        });
+        }
     }
 
     unregister(req: Request, res: Response): void {
@@ -59,6 +67,14 @@ export class Pusher {
                 message: "Failed to remove",
                 error,
             })
+        });
+    }
+
+    private sendOnRegister(res: Response, registeredDevice) {
+        sendJSONresponse(res, 200, {
+            status: 200,
+            message: "Successfully saved",
+            response: registeredDevice,
         });
     }
 }

--- a/src/controllers/PusherController.ts
+++ b/src/controllers/PusherController.ts
@@ -6,51 +6,6 @@ import { Error } from "mongoose";
 import { ISavedDevice } from "./Interfaces/IPusherController"
 
 export class Pusher {
-    register = (req: Request, res: Response) => {
-        const wallets = [...(new Set(req.body.wallets.map((wallet: string) => wallet.toLowerCase())))];
-        const inputPreferences = req.body.preferences || {};
-        const preferences = {
-            isAirdrop: inputPreferences.isAirdrop || false
-        }
-        const type: string = req.body.type || ""
-        const deviceID: string = req.body.deviceID
-        const token: string = req.body.token
-        const updateOptions = {
-            upsert: true,
-            new: true,
-            setDefaultsOnInsert: true
-        }
-        const updatesParams = {
-            deviceID,
-            wallets,
-            token,
-            preferences,
-            type
-        }
-
-        try {
-            if (deviceID && token) {
-                Device.findOneAndUpdate({deviceID}, updatesParams, updateOptions).then(registeredDevice => {
-                    this.sendOnRegister(res, registeredDevice)
-                })
-            }
-            else if (token && !deviceID && type === "android") {
-                Device.findOneAndUpdate({token}, updatesParams, updateOptions).then(registeredDevice => {
-                    this.sendOnRegister(res, registeredDevice)
-                })
-            } else {
-                throw new TypeError()
-            }
-        } catch (error) {
-            winston.error(`Failed to save device `, error);
-            sendJSONresponse(res, 500, {
-                status: 500,
-                message: "Failed to save device, check if token, deviceID, or type specified correctly",
-                error,
-              });
-        }
-    }
-
     unregister(req: Request, res: Response): void {
         Device.findOneAndRemove({
             deviceID: req.body.deviceID
@@ -67,14 +22,6 @@ export class Pusher {
                 message: "Failed to remove",
                 error,
             })
-        });
-    }
-
-    private sendOnRegister(res: Response, registeredDevice) {
-        sendJSONresponse(res, 200, {
-            status: 200,
-            message: "Successfully saved",
-            response: registeredDevice,
         });
     }
 }

--- a/src/routes/ApiRoutes.ts
+++ b/src/routes/ApiRoutes.ts
@@ -3,6 +3,7 @@ import { TransactionController } from "../controllers/TransactionController";
 import { TokenController } from "../controllers/TokenController";
 import { StatusController } from "../controllers/StatusController";
 import { Pusher } from "../controllers/PusherController";
+import { DeviceRegistration } from "../controllers/DeviceRegistrationController";
 import { PriceController } from "../controllers/PriceController";
 import { TokenPriceController } from "../controllers/TokenPriceController";
 import { AssetsController } from "../controllers/AssestsController";
@@ -13,6 +14,7 @@ const transactionController = new TransactionController();
 const tokenController = new TokenController();
 const statusController = new StatusController();
 const pusherController = new Pusher();
+const deviceRegistration = new DeviceRegistration();
 const priceController = new PriceController();
 const tokenPriceController = new TokenPriceController();
 const assetsController = new AssetsController();
@@ -30,8 +32,9 @@ router.get("/tokens/:address", tokenController.readOneToken);
 router.get("/tokenInfo/:tokenAddress", tokenController.readTokenInfo);
 
 // URLs for push notifications
-router.post("/push/register", pusherController.register);
+router.post("/push/register", deviceRegistration.register);
 router.delete("/push/unregister", pusherController.unregister);
+router.post("/push/unregister", deviceRegistration.unregister);
 
 router.get("/prices", priceController.getPrices);
 router.post("/tokenPrices", tokenPriceController.getTokenPrices);

--- a/test/PusherController.test.ts
+++ b/test/PusherController.test.ts
@@ -8,24 +8,25 @@ const should = chai.should();
 const app = new App().app;
 
 
-describe("Register device", () => {
+describe.only("Register device", () => {
     beforeEach((done) => {
-        Device.remove({}, err => {
+        Device.remove({}, () => {
             done();
         });
     });
 
     afterEach((done) => {
-        Device.remove({}, err => {
+        Device.remove({}, () => {
             done();
         });
     });
 
     const deviceID = "B14BD907-324A-4A40-98A1-A255CC6D2BE5";
     const token = "451adb42d54498d9554b4b11a749cac665558707fb488a2cf06cc259336c7db2";
+    const androidToken = "APA91bH0ZGg9AkEcnZMLUarIuT6MkvLkNB0bzGw6n6GCCZIzW8R374ocf9iMVAvVHi"
     const address = "0xc344e083393ec50bf36be81b8995b0f2aa2c5716";
 
-    it("Should register device", done => {
+    it("Should register ios device", done => {
         const device = {
             deviceID,
             token,
@@ -55,6 +56,85 @@ describe("Register device", () => {
                 done();
             });
     })
+
+    it("Should register android device", done => {
+        const device = {
+            deviceID: "",
+            token: androidToken,
+            wallets: [address],
+            type: "android"
+          }
+
+          chai.request(app)
+            .post("/push/register")
+            .send(device)
+            .end((err, res) => {
+                const body = res.body;
+                res.should.have.status(200);
+                body.should.be.a("object");
+                body.should.have.property("status").eql(200);
+                body.should.have.property("message").eql("Successfully saved");
+                body.should.have.property("response");
+
+                const response = res.body.response;
+                response.should.have.property("wallets").eql([address]);
+                response.should.have.property("preferences");
+                response.preferences.should.have.property("isAirdrop")
+                response.should.have.property("deviceID").eql("");
+                response.should.have.property("createdAt").to.be.a("string");
+                response.should.have.property("createdAt").to.be.a("string");
+                response.should.have.property("token").eql(androidToken);
+                response.should.have.property("type").to.be.a("string").and.to.be.eql("android")
+                done();
+            });
+    })
+
+    it("Should unregister ios device", () => {
+        const device = {
+            deviceID,
+            token,
+            wallets: [address],
+          }
+
+          chai.request(app)
+            .post("/push/register")
+            .send(device)
+            .end((err, res) => {
+            })
+
+          chai.request(app)
+            .delete("/push/unregister")
+            .send(device)
+            .end((err, res) => {
+                const body = res.body
+                res.should.have.status(200)
+                body.should.have.property("message").eql("Successfully unregistered")
+            })
+    });
+
+    it("Should unregister android device", () => {
+        const device = {
+            deviceID: "",
+            token: androidToken,
+            wallets: [address],
+            type: "android"
+          }
+
+          chai.request(app)
+            .post("/push/register")
+            .send(device)
+            .end((err, res) => {
+            })
+
+          chai.request(app)
+            .delete("/push/unregister")
+            .send(device)
+            .end((err, res) => {
+                const body = res.body
+                res.should.have.status(200)
+                body.should.have.property("message").eql("Successfully unregistered")
+            })
+    });
 
     it("Should register only one wallet if dublicates present", done => {
         const device = {

--- a/test/PusherController.test.ts
+++ b/test/PusherController.test.ts
@@ -8,7 +8,7 @@ const should = chai.should();
 const app = new App().app;
 
 
-describe.only("Register device", () => {
+describe("Register device", () => {
     beforeEach((done) => {
         Device.remove({}, () => {
             done();

--- a/test/PusherController.test.ts
+++ b/test/PusherController.test.ts
@@ -45,6 +45,7 @@ describe("Register device", () => {
                 body.should.have.property("response");
 
                 const response = res.body.response;
+                response.should.not.have.property("_id")
                 response.should.have.property("wallets").eql([address]);
                 response.should.have.property("preferences");
                 response.preferences.should.have.property("isAirdrop")
@@ -77,6 +78,7 @@ describe("Register device", () => {
                 body.should.have.property("response");
 
                 const response = res.body.response;
+                response.should.not.have.property("_id")
                 response.should.have.property("wallets").eql([address]);
                 response.should.have.property("preferences");
                 response.preferences.should.have.property("isAirdrop")
@@ -108,6 +110,7 @@ describe("Register device", () => {
             .end((err, res) => {
                 const body = res.body
                 res.should.have.status(200)
+                res.should.not.have.property("_id")
                 body.should.have.property("message").eql("Successfully unregistered")
             })
     });
@@ -132,6 +135,7 @@ describe("Register device", () => {
             .end((err, res) => {
                 const body = res.body
                 res.should.have.status(200)
+                res.should.not.have.property("_id")
                 body.should.have.property("message").eql("Successfully unregistered")
             })
     });


### PR DESCRIPTION
PR bring next changes to `unregister` endpoint:
1. `DELETE /push/unregister` => `POST /push/unregister/`.  `DELETE` will be available till mass adoption of `POST` 
2.  Response from `/push/unregister` change from:
```js
{
  status:  boolean,
  ...
}
```
to:
```js
{
  status:  number, // status code
  ...
}
```
