### PR TITLE
Allowing to Filter Contract Interactions on Addresses

### DIFF
--- a/src/controllers/TransactionController.ts
+++ b/src/controllers/TransactionController.ts
@@ -147,7 +147,7 @@ export class TransactionController {
 
         // filter non-address calls parameter
         let filterContractInteraction = false;
-        if (req.query.filterContractInteraction && req.query.filterContractInteraction !== 'false') {
+        if (req.query.filterContractInteraction && req.query.filterContractInteraction !== "false") {
             filterContractInteraction = true
         }
 

--- a/src/controllers/TransactionController.ts
+++ b/src/controllers/TransactionController.ts
@@ -35,6 +35,12 @@ export class TransactionController {
             }
         }
 
+        if (queryParams.filterContractInteraction) {
+            Object.assign(query, { $or: [
+                { from: { $eq: address } },
+                { to: { $eq: address } }
+            ]})
+        }
 
         Transaction.paginate(query, {
             page: queryParams.page,
@@ -100,8 +106,9 @@ export class TransactionController {
         req.checkQuery("startBlock", "startBlock needs to be a number").optional().isNumeric();
         req.checkQuery("endBlock", "endBlock needs to be a number").optional().isNumeric();
         req.checkQuery("limit", "limit needs to be a number").optional().isNumeric();
-        req.checkQuery("address", "address needs to be alphanumeric and have a length 42").isAlphanumeric().isLength({min: 42, max: 42});
-        req.checkQuery("contract", "contract symbol needs to be alphanumeric and have a length 42").optional().isAlphanumeric().isLength({min: 42, max: 42});
+        req.checkQuery("address", "address needs to be alphanumeric and have a length 42").isAlphanumeric().isLength({ min: 42, max: 42 });
+        req.checkQuery("contract", "contract symbol needs to be alphanumeric and have a length 42").optional().isAlphanumeric().isLength({ min: 42, max: 42 });
+        req.checkQuery("filterContractInteraction", "filterContractInteraction needs to be boolean").optional().isString();
 
         return req.validationErrors();
     }
@@ -138,6 +145,12 @@ export class TransactionController {
             endBlock = 9999999999;
         }
 
+        // filter non-address calls parameter
+        let filterContractInteraction = false;
+        if (req.query.filterContractInteraction && req.query.filterContractInteraction !== 'false') {
+            filterContractInteraction = true
+        }
+
         const contract = req.query.contract;
 
         return {
@@ -146,7 +159,8 @@ export class TransactionController {
             endBlock: endBlock,
             page: page,
             limit,
-            contract
+            contract,
+            filterContractInteraction
         };
     }
 


### PR DESCRIPTION
Hi everyone!

We're currently building a wallet as well and found your API very helpful. There is one tidbit missing for us however, and that is to achieve a seperation between TXs that are triggered by the user himself (contract calls, outgoing token transfers) and TXs that are triggered elsewhere but concern the user (incoming token TX).

This is similar to how etherscan.io handles it, check for example this address:

https://api.trustwalletapp.com/transactions?address=0x73494BCb0865a72fD03cb3242e4C7b48688c0fEb

Where there are a number of regular transactions listed (19) and also a number of token transfers (4).

In the Trust-Ray however, querying this address also includes incoming Token TXs, such as this specific TX (https://etherscan.io/tx/0x7191912093be786389a8e2de704586670ff72b0a4c097a38c146d5ba1a3766f0), so the API returns 20 txs.

The mentioned one is an incoming token transfer, which in case of random airdrops or a lot of trades with tokens on decentralized exchanges, can quickly spam your TX-list.

To filter out only TXs that are initiated by your own address or are direct ether transfers to your address, we implemented an additional filter called "filterContractInteraction" (the naming can be changed however, if you have a better name in mind?)

Performance-wise, as this is just another filter on the query, there isn't a lof of performance hits to expect, and the pagination works as is (which is why we were unable to do the filter on our side).

_Please let us know if this is sth that you would merge into your version, or if any changes are necessary!_